### PR TITLE
Paging for list

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,19 @@ export type MobilettoVisitor = (meta: MobilettoMetadata) => Promise<unknown>;
 export type MobilettoListOptions = {
     recursive?: boolean;
     visitor?: MobilettoVisitor;
+    paging?: MobilettoListPaging;
 };
+
+export type MobilettoListPaging = {
+    maxItems: number;
+    continuationToken?: string;
+};
+
+export type MobilettoListOutput = {
+    objects: MobilettoMetadata[];
+    nextPageToken?: string;
+    previousPageToken?: string;
+}
 
 export type MobilettoSyncReadFunc = { next: () => { value: Buffer } };
 export type MobilettoAsyncReadFunc = { next: () => Promise<{ value: Buffer }> };
@@ -88,7 +100,7 @@ export type MobilettoMinimalClient = MobilettoPatchable & {
         pth?: string,
         optsOrRecursive?: MobilettoListOptions | boolean,
         visitor?: MobilettoVisitor
-    ) => Promise<MobilettoMetadata[]>;
+    ) => Promise<MobilettoListOutput>;
     metadata: (path: string) => Promise<MobilettoMetadata>;
     read: (path: string, callback: (chunk: Buffer) => void, endCallback?: () => void) => Promise<number>;
     write: (path: string, data: MobilettoWriteSource) => Promise<number>;


### PR DESCRIPTION
Hey @cobbzilla 

To support paging for list method I propose:

1. For request add optional param`paging?: MobilettoListPaging;` to `MobilettoListOptions`
```typescript
export type MobilettoListPaging = {
    maxItems: number;
    continuationToken?: string;
};
```

2. It will require a breaking change version up because of new return type`MobilettoListOutput` that will include array and optional params for next requests
```typescript
export type MobilettoListOutput = {
    objects: MobilettoMetadata[];
    nextPageToken?: string;
    previousPageToken?: string;
}
```
  2.1 Even though it's breaking change, but update on client usage is simple, for example it will be
```typescript
const { objects } = await api.list();
// with named result object
const { objects: noSlash } = await fixture.api.list(randomParent);
```

Also, because of missing packages I have created mono repo that:
- includes base and common changes for paging
- s3 driver paging initial implementation and tests for paging

https://github.com/ssleptsov/mobiletto-mono/